### PR TITLE
Convert depth to meters

### DIFF
--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -238,7 +238,7 @@ public:
 			for(int x = 0; x < depthFrame.width(); x++)
 			{
 				std::size_t pixelOffset = (y * depthFrame.width()) + x;
-				img.at<float>(y, x) = buf[pixelOffset];
+				img.at<float>(y, x) = buf[pixelOffset] * 0.001f;
 			}
 		}
 


### PR DESCRIPTION
The depth in `float` format should represent meters, not millimeters.

Before this PR:
![screenshot from 2019-03-05 19-24-40](https://user-images.githubusercontent.com/382167/53828553-4ce4c100-3f7e-11e9-8c66-e3779469f213.png)

You can clearly see that the values are saturated to black and white because the values in the image are `1000` times larger than they should.

After this PR:
![screenshot from 2019-03-05 19-23-33](https://user-images.githubusercontent.com/382167/53828558-50784800-3f7e-11e9-906c-702eb07faed4.png)

Obviously, the color image is completely broken.

It's a shame though that the `ST` SDK doesn't support the `uint16_t` format.