### PR TITLE
Add depth correction enable param

### DIFF
--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -238,7 +238,7 @@ public:
 			for(int x = 0; x < depthFrame.width(); x++)
 			{
 				std::size_t pixelOffset = (y * depthFrame.width()) + x;
-				img.at<float>(y, x) = buf[pixelOffset];
+				img.at<float>(y, x) = buf[pixelOffset] * 0.001f;
 			}
 		}
 

--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -351,6 +351,8 @@ private:
 
 	bool imu_enable_;
 
+	bool depth_correction_enable_;
+
 	SessionDelegate *delegate_ = nullptr;
 	ST::CaptureSessionSettings sessionConfig_;
 	ST::CaptureSession captureSession_;
@@ -374,6 +376,9 @@ public:
 		ros::param::param<bool>("~imu_enable", imu_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": imu_enable = " << imu_enable_);
 
+		ros::param::param<bool>("~depth_correction_enable", depth_correction_enable_, false);
+		ROS_INFO_STREAM(NODE_NAME << ": depth_correction_enable = " << depth_correction_enable_);
+
 		std::string frame_id;
 		ros::param::param<std::string>("~frame_id", frame_id, DEFAULT_FRAME_ID);
 		ROS_INFO_STREAM(NODE_NAME << ": frame_id = " << frame_id);
@@ -393,6 +398,7 @@ public:
 
 		sessionConfig_.source = ST::CaptureSessionSourceId::StructureCore;
 		sessionConfig_.structureCore = scConfig;
+		sessionConfig_.applyExpensiveCorrection = depth_correction_enable_;
 
 		delegate_ = new SessionDelegate(nh_, frame_id, sessionConfig_);
 		captureSession_.setDelegate(delegate_);


### PR DESCRIPTION
On top of https://github.com/AutoModality/struct_core_ros/pull/7, this adds the `depth_correction_enable` param, so we can get a cleaner depth image.

Before this PR:
![before](https://user-images.githubusercontent.com/382167/53828558-50784800-3f7e-11e9-906c-702eb07faed4.png)

After this PR with `depth_correction_enable: true` set:
![screenshot from 2019-03-05 19-34-35](https://user-images.githubusercontent.com/382167/53828787-e90ec800-3f7e-11e9-92f6-7f3ec774eddf.png)
